### PR TITLE
Human-readable processed bytes in volume.fix.replication

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -15,6 +15,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle_map"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"google.golang.org/grpc"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
@@ -362,7 +363,7 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 						}
 					}
 					if resp.ProcessedBytes > 0 {
-						fmt.Fprintf(writer, "volume %d processed %d bytes\n", replica.info.Id, resp.ProcessedBytes)
+						fmt.Fprintf(writer, "volume %d processed %d bytes\n", replica.info.Id, util.BytesToHumanReadable(uint64(resp.ProcessedBytes)))
 					}
 				}
 


### PR DESCRIPTION
# What problem are we solving?
Right now shell command `volume.fix.replication` prints raw processed bytes size, but in new commands `util.BytesToHumanReadable(uint64(resp.ProcessedBytes))` often used.


# How are we solving the problem?
Using `util.BytesToHumanReadable(uint64(resp.ProcessedBytes))` in `volume.fix.replication` command


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
